### PR TITLE
Substitute os.devnull for "/dev/null"

### DIFF
--- a/genomics/popgen/ne2/controller.py
+++ b/genomics/popgen/ne2/controller.py
@@ -111,7 +111,7 @@ class NeEstimator2Controller(object):
             opf.write('0\n')
             opf.close()
         os.system(self.ne2_dir + os.sep + self.bin_name +
-                  ' i:' + in_name + opt_txt + ' >/dev/null 2>&1')
+                  ' i:' + in_name + opt_txt + ' >' + os.devnull + ' 2>&1')
         os.remove(in_name)
         if len(options) > 0:
             os.remove(opt_name)


### PR DESCRIPTION
For the system call command that executes Ne2, substituted os.devnull for "/dev/null" to adapt controller.py code for Windows platforms
